### PR TITLE
Update workflow to fail on empty JSON

### DIFF
--- a/.github/workflows/rss-generator.yml
+++ b/.github/workflows/rss-generator.yml
@@ -30,7 +30,12 @@ jobs:
 
       - name: Fetch JSON and Convert to RSS
         run: |
-          curl -sL "https://kosodate-green.mlit.go.jp/assets/data/news.json" -o news.json
+          curl -fSL "https://kosodate-green.mlit.go.jp/assets/data/news.json" -o news.json
+
+          if [ ! -s news.json ]; then
+            echo "news.json is empty" >&2
+            exit 1
+          fi
 
           # デバッグ用に JSON の内容を表示
           echo "Fetched JSON Content:"


### PR DESCRIPTION
## Summary
- fetch news.json with `curl -fSL`
- stop the workflow if `news.json` is empty

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68482802529c8333a00251cf9b3a1998