### PR TITLE
Add XML validation to workflow

### DIFF
--- a/.github/workflows/rss-generator.yml
+++ b/.github/workflows/rss-generator.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install -y jq
+          sudo apt-get install -y jq libxml2-utils
 
       - name: Fetch previous RSS file
         run: |
@@ -75,6 +75,10 @@ jobs:
             echo "❌ rss.xml NOT FOUND!"
             exit 1
           fi
+
+      - name: Validate RSS file
+        run: |
+          xmllint --noout rss.xml
 
       - name: Ensure .nojekyll exists
         run: |


### PR DESCRIPTION
## Summary
- install `libxml2-utils` for `xmllint`
- validate generated `rss.xml` with `xmllint`

## Testing
- `xmllint --noout rss.xml` *(fails: command not found)*
- `sudo apt-get update -y` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_b_684828048e388333bb9424d13bfe6548